### PR TITLE
Cleanup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For use at NSIDC, this project requires the [vagrant-nsidc-plugin](https://bitbu
 
 Dependencies are defined in the CI configuration and should be available upon machine provision.
 
+Note that the `search-solr-tools` gem is **not** installed via Bundler.
+See the entries matching the strings `deploy_solr_tools_command` and
+`Deploy_solr-search-tools-gem` in `puppet/ci.yaml`.
+
 ## Setup
 The virtual machine will be provisioned using the
 [puppet-nsidc-solr](https://bitbucket.org/nsidc/puppet-nsidc-solr) module.

--- a/puppet/ci.yaml
+++ b/puppet/ci.yaml
@@ -53,7 +53,7 @@ deploy_solr_tools_command: |
   # 'gem uninstall -x' removes the installed version and related executables
   # 'gem list' will show the installed versions to confirm that only the desired
   #    version is installed
-  vagrant nsidc ssh --env=$ENV --project=search-solr -c "sudo gem cleanup search_solr_tools; sudo gem uninstall -x search_solr_tools; sudo gem install search_solr_tools $VERSION -s http://snowhut.apps.int.nsidc.org/shares/export/sw/packages/ruby/nsidc; sudo gem list --local search_solr_tools"
+  vagrant nsidc ssh --env=$ENV --project=search-solr -c "sudo gem cleanup search_solr_tools; sudo gem uninstall -x search_solr_tools; sudo gem install search_solr_tools $VERSION; sudo gem list --local search_solr_tools"
 
 provision_solr_command: |
   rm -rf .vagrant-$ENV

--- a/puppet/site.pp
+++ b/puppet/site.pp
@@ -40,7 +40,7 @@ if $environment == 'ci' {
   }
 }
 
-if ($environment == 'local') or ($environment == 'dev') or ($environment == 'integration') or ($environment == 'qa') or ($environment == 'staging') or ($environment == 'production') or ($environment == 'blue') or ($environment == 'green') or ($environment == 'red') {
+unless $environment == 'ci' {
   # Ensure the brightbox apt repository gets added before installing ruby
   include apt
   apt::ppa{'ppa:brightbox/ruby-ng':}


### PR DESCRIPTION
- Remove old reference to snowhut for the installation of `search-solr-tools`, since the gem in question is now installed via rubygems.
- Add a note to clarify that the `search-solr-tools` dependency is not managed by Bundler (Bundler-savvy developers tend to look in `Gemfile` to find gem dependencies).
